### PR TITLE
Drop support for ruby 2.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
       matrix:
         ruby:
           - '3.1.2'
+          - '3.0.4'
+          - '2.7.6'
 
     steps:
     - uses: actions/checkout@v3

--- a/rack-change-password-url.gemspec
+++ b/rack-change-password-url.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "Provides endpoint of a Well-Known URL for Changing Passwords"
   spec.homepage = "https://github.com/taketo1113/rack-change-password-url"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/taketo1113/rack-change-password-url"


### PR DESCRIPTION
## Summary
Drop support for ruby 2.6 (reached EoL on 2022/03/31)

## Related URL
- Ruby Maintenance Branches
  - https://www.ruby-lang.org/en/downloads/branches/