### PR TITLE
Add Ruby 3.3 to the CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - '3.3'
           - '3.2'
           - '3.1'
           - '3.0'


### PR DESCRIPTION
## Summary
Update the CI matrix for Ruby 3.3.

## Changes
- add ruby 3.3 for ci

## Related URL
- Ruby 3.3.0 Released
  - https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/
