### PR TITLE
CI: fix to check response header of content-length for rack v3.1.x

### DIFF
--- a/spec/rack-change-password-url/middleware_spec.rb
+++ b/spec/rack-change-password-url/middleware_spec.rb
@@ -50,7 +50,11 @@ RSpec.describe Rack::ChangePasswordUrl::Middleware do
       get @path
 
       expect(last_response.status).to eq 200
-      expect(last_response.headers).to eq({})
+      if Gem::Version.new(Rack.release) >= Gem::Version.new("3.1.0")
+        expect(last_response.headers).to eq({ "content-length" => "16" })
+      else
+        expect(last_response.headers).to eq({})
+      end
       expect(last_response.body).to eq 'Example App Body'
     end
   end


### PR DESCRIPTION
## Summary
CI: check response header of content-length for rack v3.1.x

## Changes
- spec: check response header of content-length for rack v3.1.x
