### PR TITLE
Add ruby 3.4 to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - '3.4'
           - '3.3'
           - '3.2'
           - '3.1'


### PR DESCRIPTION
## Summary
Update the CI matrix for Ruby 3.4.

## Changes
- add ruby 3.4 to CI

## Related URL
- Ruby 3.4.0 Released
  - https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/
