### PR TITLE
Add irb as a development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "irb"
+
 # overwrite gemspec dependencies for CI
 unless ENV['RACK_VERSION'].nil?
   gem 'rack', "~> #{ENV['RACK_VERSION']}"


### PR DESCRIPTION
## Summary
This Pull Request adds irb gem as a development dependency.

## Changes
It fixes the followed warning.
```
$ bin/console
bin/console:14: warning: irb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add irb to your Gemfile or gemspec to silence this warning.
>
```
