### PR TITLE
CI: Add Ruby 4.0 to CI Matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - '4.0'
           - '3.4'
           - '3.3'
           - '3.2'


### PR DESCRIPTION
## Summary
This Pull Request addes Ruby 4.0 to CI Matrix.

## Changes
- add ruby 4.0 to CI

## Related URL
- Ruby 4.0.0 Released | Ruby
  - https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/
